### PR TITLE
feat: enable using the package.json repo url as the repositoryUrl for sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 | `org` | The slug of the organization. Optional. Required if not present in environment variables |
 | `url` | The URL to use to connect to sentry. Optional to set an on-premise instance |
 | `repositoryUrl` | A valid repository name for add link to commits of new release. Optional. Ex: 'myorg / myapp' |
+| `usePackageRepositoryUrl` | If set to `true`, the repository defined in the `package.json` is used.  |
 | `tagsUrl` | A valid url for add link to new release. Optional. Ex: https://github.com/owner/repo/releases/tag/vx.y.z |
 | `environment` | Sentry environment. Optional for deploy. Default production |
 | `deployName` | Deploy name. Optional for deploy |

--- a/src/publish.js
+++ b/src/publish.js
@@ -67,6 +67,12 @@ module.exports = async (pluginConfig, ctx) => {
         }
         if (pluginConfig.repositoryUrl) {
           newCommit.repository = pluginConfig.repositoryUrl
+        } else if (
+          !pluginConfig.repositoryUrl &&
+          pluginConfig.usePackageRepositoryUrl === true &&
+          ctx.options.repositoryUrl
+        ) {
+          newCommit.repository = ctx.options.repositoryUrl
         }
         return newCommit
       }),

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,6 +13,7 @@ export interface Context extends SemanticReleaseContext, SemanticReleaseConfig, 
 export interface Config {
   // Set url of repository tags. Ex: https://gitlab.com/my-org/my-repo
   repositoryUrl?: string
+  usePackageRepositoryUrl?: boolean
   // Set url of repository tags. Ex: https://gitlab.com/my-org/my-repo/-/tags
   tagsUrl?: string
   environment?: string


### PR DESCRIPTION
With this feature it is possible to just use the repo url defined in the package.json.
The value is provided by the ctx of semantic-release.

The advantage is to just define the repo url once in a project.