### PR TITLE
feat(request): allow response status code 208 when requesting

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -55,7 +55,7 @@ const request = (path, data, token, url) =>
         try {
           const bodyString = Buffer.concat(chunks, totalLength).toString()
           const body = JSON.parse(bodyString)
-          if (res.statusCode !== 201) {
+          if (![201, 208].includes(res.statusCode)) {
             return reject(
               new Error(
                 `Invalid status code: ${res.statusCode}\nResponse: ${bodyString}`


### PR DESCRIPTION
What - allow http 208 response from sentry when creating resources

Why - Sentry returns http status 208 when requesting to create a release that already exists. Current implementation fails the request, even though the release exists.
How can this happen
- we run semantic-release in dry-run mode to get next version number
- we deploy app with version from previous step
- now there is an error that is reported to sentry. This error is marked with new version number and creates a new release in sentry (sentry does this automatically)
- right after successful deployment we run semantic-release with this plugin. But since there was an error reported to sentry with new version before we could run semantic-release, sentry will return http 208 for new release and this plugin will fail